### PR TITLE
avoid setting every aggregate value to null

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ function PostgresAdapter(config) {
                 _.each(points, function(pt) {
                     _.each(self.aggregation_targets, function(aggregation_field) {
                         if (pt.hasOwnProperty(aggregation_field)) {
-                            pt[aggregation_field] = parseFloat(pt[aggregation_field]);
-                            if (isNaN(pt[aggregation_field])) {
-                                pt[aggregation_field] = null;
+                            var value = parseFloat(pt[aggregation_field]);
+                            if (!isNaN(value)) {
+                                pt[aggregation_field] = value;
                             }
                         }
                     });


### PR DESCRIPTION
Cannot set `NaN` values to `null` because it will not match the empty aggregate. 

The testing for this is here: https://github.com/juttle/juttle-sql-adapter-common/pull/32
The issue is here: https://github.com/juttle/juttle-postgres-adapter/issues/16
